### PR TITLE
[codex] Restore README before April 4 Apify sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,168 @@
-# GoKollab Downloader
+# GoKollab Downloader (Browser Extension)
 
-> Save GoKollab content instantly to your device.
+> Download videos, images, GIFs, and text from GoKollab course pages and supported GoHighLevel-powered portals.
 
-## Get the extension
+GoKollab Downloader is a browser extension built for mixed-media course pages. It helps you save lesson videos, images, GIFs, and page text from GoKollab and supported GoHighLevel-powered learning portals, using a single browser workflow instead of separate tools for each content type.
 
-**Install here:** [GoKollab Downloader](https://serp.ly/gokollab-downloader)
+- Save lesson videos as MP4 files
+- Download images and GIFs from visible course pages
+- Export page text for notes or archiving
+- Capture supported embedded players like Loom, Vimeo, Wistia, and YouTube
+- Bulk-download visible assets from the current lesson page
 
-Use the product page above to get the browser extension and install instructions.
+## Links
 
-- Product page: https://serp.ly/gokollab-downloader
-- Chrome Web Store: https://chromewebstore.google.com/detail/gokollab-downloader/ocmeocpipampilemclcclaokgbjejhab
-- GitHub repo: https://github.com/serpapps/gokollab-downloader
-- Latest release: https://github.com/serpapps/gokollab-downloader/releases/latest
+- :rocket: Get it here: [GoKollab Downloader](https://serp.ly/gokollab-downloader)
+- :new: Latest release: [GitHub Releases](https://github.com/serpapps/gokollab-downloader/releases/latest)
+- :question: Help center: [SERP Help](https://help.serp.co/en/)
+- :beetle: Report bugs: [GitHub Issues](https://github.com/serpapps/gokollab-downloader/issues)
+- :bulb: Request features: [Feature Requests](https://github.com/serpapps/gokollab-downloader/issues)
 
-![GoKollab Downloader](https://raw.githubusercontent.com/serpapps/gokollab-downloader/main/images/gokollab-downloader.gif)
+## Preview
 
-## What It Does
+![GoKollab Downloader workflow preview](assets/workflow-preview.webp)
 
-- Detects GoKollab native videos plus YouTube, Vimeo, Wistia, and Loom embeds
-- Works across workspaces, teams, and knowledge bases using your existing access
-- Quality picker surfaces every available resolution with format labels and sizes
-- Converts HLS and DASH streams into standard MP4 without losing quality
-- Progress window tracks stage, speed, ETA, and offers pause/cancel controls
-- Right-click “Capture with GoKollab Downloader” for fast saves inside workspaces
-- Stores licence details and preferences locally with no analytics or tracking
-- Desktop notifications signal completion so you can multitask
-- Compatible with Chrome, Edge, Firefox, Brave, and Opera on desktop
-- Built on Manifest V3 with permissions limited to GoKollab and supported hosts
+## Table of Contents
 
-## Compatibility
+- [Why GoKollab Downloader](#why-gokollab-downloader)
+- [Features](#features)
+- [How It Works](#how-it-works)
+- [Step-by-Step Tutorial: How to Download Content from GoKollab](#step-by-step-tutorial-how-to-download-content-from-gokollab)
+- [Supported Formats](#supported-formats)
+- [Who It's For](#who-its-for)
+- [Common Use Cases](#common-use-cases)
+- [Troubleshooting](#troubleshooting)
+- [Trial & Access](#trial--access)
+- [Installation Instructions](#installation-instructions)
+- [FAQ](#faq)
+- [Notes](#notes)
+- [About GoKollab](#about-gokollab)
 
-- Supported platforms: windows, mac, linux, chrome, firefox, edge, opera
-- Categories: Downloader, Course Platforms, Video Downloader
+## Why GoKollab Downloader
+
+GoKollab pages often contain more than just one video. Lessons can mix embedded walkthroughs, native training clips, images, GIFs, and text content on the same page, which makes manual saving slow and messy if you are trying to preserve a full lesson or build an offline archive.
+
+GoKollab Downloader is built for that exact workflow. It scans the current page for visible assets, groups them by type, and gives you a direct way to download the content you need from a single popup.
+
+## Features
+
+- Multi-asset detection for videos, images, GIFs, and text
+- Support for GoKollab pages and supported GoHighLevel-powered portals
+- Embedded player support for Loom, Vimeo, Wistia, and YouTube
+- MP4 export for detected videos
+- Source-format saving for images and GIFs
+- TXT export for visible lesson text
+- Bulk-download workflow for all visible assets on the page
+- Tabbed popup for videos, images/GIFs, and text
+- Cross-browser support for Chrome, Edge, Brave, Opera, Firefox, Whale, and Yandex
+
+## How It Works
+
+1. Install the extension from the latest release.
+2. Open a GoKollab lesson page or supported GoHighLevel-powered page.
+3. Let the page load and play any video you want the extension to detect.
+4. Open the popup to review detected videos, images, GIFs, and text.
+5. Download individual assets or save the visible set in bulk.
+6. Open the exported files from your Downloads folder.
+
+## Step-by-Step Tutorial: How to Download Content from GoKollab
+
+1. Install GoKollab Downloader from the latest GitHub release.
+2. Sign in to the course or portal where you already have access.
+3. Open the lesson page you want to save.
+4. Let the page load fully and press play on any lesson video.
+5. Click the extension button in your browser toolbar.
+6. Review the detected videos, images/GIFs, and text content.
+7. Download individual items or run a bulk download for the full visible lesson.
+8. Open the saved files from your Downloads folder.
+
+## Supported Formats
+
+- Videos: MP4
+- Images and GIFs: source format where available
+- Text: TXT
+
+Saved exports are designed to make it easier to keep a complete local copy of a lesson page, not just the video.
+
+## Who It's For
+
+- GoKollab students saving lessons for offline study
+- Coaches and consultants preserving course materials
+- Teams archiving mixed-media training pages
+- Users who want one tool for video, images, and lesson text together
+- Anyone building a local reference library from supported learning portals
+
+## Common Use Cases
+
+- Save a full lesson page with video, images, and text
+- Download embedded Loom or Vimeo walkthroughs from a GoKollab course
+- Export page text for notes, SOPs, or internal docs
+- Archive mixed-media lessons before access changes
+- Bulk-download all visible lesson assets in one pass
+
+## Troubleshooting
+
+**The extension is not finding the lesson video**  
+Press play first and wait a few seconds so the video source has time to initialize.
+
+**Images or GIFs are missing**  
+Scroll through the lesson so the full asset set is visible before scanning again.
+
+**Text export looks incomplete**  
+Expand any collapsed sections on the page before scanning.
+
+**The page is not being recognized**  
+Make sure you are on a GoKollab page or a supported GoHighLevel-powered portal.
+
+**The lesson requires login or membership access**  
+The extension only works on content you can already access in your active browser session.
+
+## Trial & Access
+
+- Includes **3 free downloads** so you can test the workflow first
+- Email sign-in uses secure one-time password verification
+- No credit card required for the trial
+- Unlimited downloads are available with a paid license
+
+Start here: [https://serp.ly/gokollab-downloader](https://serp.ly/gokollab-downloader)
+
+## Installation Instructions
+
+1. Open the latest release page:
+   [https://github.com/serpapps/gokollab-downloader/releases/latest](https://github.com/serpapps/gokollab-downloader/releases/latest)
+2. Download the extension build for your browser.
+3. Install the extension.
+4. Open a GoKollab lesson or supported portal page.
+5. Use the extension popup to detect and download visible assets.
 
 ## FAQ
 
-### How do I capture a GoKollab video?
+**What kinds of content can I download from GoKollab?**  
+Videos, images, GIFs, and visible lesson text from supported pages.
 
-Open the workspace post or module, click the GoKollab Downloader icon, choose your preferred resolution, and keep the tab open while the progress bar completes. The MP4 will save using the workspace and item name.
+**Does it only work with videos?**  
+No. The extension is built for mixed-media lesson pages, including non-video assets.
 
-### Does it support multiple workspaces and teams?
+**Can I bulk-download the full page content?**  
+Yes. The extension supports bulk export for visible assets on the current page.
 
-Yes. The extension uses your active GoKollab session and respects project and team permissions, so any video you can watch can be captured.
+**Does it support embedded platforms?**  
+Yes. Supported embedded players include Loom, Vimeo, Wistia, and YouTube.
 
-### Can I queue entire workspaces?
+**Do I need extra software?**  
+No. Everything runs through the browser extension.
 
-Captures are launched one video at a time. You can line up several clips, but there is no full-workspace export or automatic bundling.
+## License
 
-### Are captions or transcripts included?
+This repository is distributed under the proprietary SERP Apps license in the [LICENSE](LICENSE) file. Review that file before copying, modifying, or redistributing any part of this project.
 
-The downloader focuses on video and audio. Captions, transcripts, and attached docs remain in GoKollab, so download those separately if you need them.
+## Notes
 
-### Which browsers are supported?
+- Only download content you own or have explicit permission to save
+- The extension works on content you can already access in your browser session
+- Some videos may need playback to start before detection works
+- Visible content may need to be fully loaded before scanning
 
-Builds are available for Chrome, Edge, Firefox, Brave, and Opera on Windows, macOS, and Linux. Safari and mobile browsers aren’t supported.
+## About GoKollab
 
-### Why does it need host permissions for embed providers?
-
-Workspaces frequently embed third-party players. Host permissions let the extension detect those streams so you can download everything you’re authorised to view.
-
-### Is my workspace data secure?
-
-Absolutely. All detection and conversion occurs locally, only licence checks touch external servers, and no viewing history or credentials are stored.
+GoKollab is used for courses, community content, and mixed-media learning pages that can combine video, imagery, and text in one lesson. That makes offline saving harder than on a simple single-video site because users often need the full lesson context, not just one media file. GoKollab Downloader simplifies that workflow for users who need a cleaner local archive of supported lesson content.


### PR DESCRIPTION
## Summary

- restore `README.md` to the exact blob from immediately before the April 4, 2026 Apify README overwrite
- keep the valid Apify actor changes intact by avoiding a full commit revert

## Why

The README was replaced by the Apify copy sync that started at commit `01cc062c2c1b47d9ebeca168741bacfde617721a`. This PR restores only the README from `e2b741b457b098e5bd739743b183e219372986e2`.

## Verification

- compared `main...head` and confirmed the branch diff is README-only
- restore source: `e2b741b457b098e5bd739743b183e219372986e2:README.md`