### PR TITLE
docs: add README video embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ GoKollab Downloader is a browser extension built for mixed-media course pages. I
 - Capture supported embedded players like Loom, Vimeo, Wistia, and YouTube
 - Bulk-download visible assets from the current lesson page
 
+## Watch The Video
+
+<a href="https://www.youtube.com/watch?v=86Pq6QKoTyY" target="_blank">
+<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-gokollab-videos.jpg" width="700px">
+</a>
+
 ## Links
 
 - :rocket: Get it here: [GoKollab Downloader](https://serp.ly/gokollab-downloader)
@@ -20,7 +26,7 @@ GoKollab Downloader is a browser extension built for mixed-media course pages. I
 
 ## Preview
 
-![GoKollab Downloader workflow preview](assets/workflow-preview.webp)
+![GoKollab Downloader workflow preview](https://raw.githubusercontent.com/serpapps/gokollab-downloader/refs/heads/main/assets/workflow-preview.webp)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ GoKollab Downloader is a browser extension built for mixed-media course pages. I
 - Capture supported embedded players like Loom, Vimeo, Wistia, and YouTube
 - Bulk-download visible assets from the current lesson page
 
-## Watch The Video
-
-<a href="https://www.youtube.com/watch?v=86Pq6QKoTyY" target="_blank">
-<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-gokollab-videos.jpg" width="700px">
-</a>
-
 ## Links
 
 - :rocket: Get it here: [GoKollab Downloader](https://serp.ly/gokollab-downloader)
@@ -26,7 +20,9 @@ GoKollab Downloader is a browser extension built for mixed-media course pages. I
 
 ## Preview
 
-![GoKollab Downloader workflow preview](https://raw.githubusercontent.com/serpapps/gokollab-downloader/refs/heads/main/assets/workflow-preview.webp)
+<a href="https://www.youtube.com/watch?v=86Pq6QKoTyY" target="_blank">
+<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/how-to-download-gokollab-videos.jpg" width="700px">
+</a>
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- Adds the Watch The Video README section from the reviewed dry-run file
- Converts local README image references to raw GitHub URLs where applicable

## Notes
- This PR was created from the local dry-run README preview.
- No force push was used.
